### PR TITLE
7 card style

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -18,7 +18,6 @@
 .cards > ul > li {
   height:314px;
   width: 448px;
-  border: 0px solid #dadada;
   background-color: var(--background-color);
   border-radius: 16px;
   position: relative;
@@ -31,7 +30,7 @@
 .cards .cards-card-image {
   height: 180px;
   overflow: hidden;
-  border-radius: 16px 16px 0px 0px;
+  border-radius: 16px 16px 0 0;
 }
 
 .cards > ul > li img {
@@ -62,7 +61,6 @@
   font-style: normal;
   font-weight: 700;
   line-height: 130%;
-  margin: 0px;
 }
 
 
@@ -71,7 +69,7 @@
 }
 
 
-@media (max-width: 1600px) {
+@media (width <= 1600px) {
   .cards > ul {
     max-width: 1500px; /* Limits the maximum width of the cards container */
     margin: 0;
@@ -82,12 +80,13 @@
     width: 448px;
     height: 314px;
   }
+
   .cards-card-body {
     height: 169px;
   }
 }
 
-@media (max-width: 1280px) {
+@media (width <= 1280px) {
   .cards > ul {
     flex-wrap: wrap;
     width: 100%;
@@ -99,12 +98,13 @@
     width: 355px;
     height: 375px;
   }
+
   .cards-card-body {
     height: 230px;
   }
 }
 
-@media (max-width: 900px) {
+@media (width <= 900px) {
   .cards > ul {
     flex-wrap: wrap;
     width: 100%;
@@ -116,12 +116,13 @@
     width: 408px;
     height: 355px;
   }
+
   .cards-card-body {
     height: 210px;
   }
 }
 
-@media (max-width: 600px) {
+@media (width <= 600px) {
   .cards > ul {
     margin: 0;
   }
@@ -130,6 +131,7 @@
     width: 272px;
     height: 400px;
   }
+  
   .cards-card-body {
     height: 255px;
   }

--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -1,15 +1,27 @@
+.cards {
+    display: flex;
+    justify-content: center;
+  }
+  
+  
 .cards > ul {
   list-style: none;
+  gap: 96px 64px;
   margin: 0;
   padding: 0;
-  display: grid;
+  display: flex;
   grid-template-columns: repeat(auto-fill, minmax(257px, 1fr));
-  grid-gap: 24px;
+  justify-content: center;
+  flex-wrap: wrap;
 }
 
 .cards > ul > li {
-  border: 1px solid #dadada;
+  height:314px;
+  width: 448px;
+  border: 0px solid #dadada;
   background-color: var(--background-color);
+  border-radius: 16px;
+  position: relative;
 }
 
 .cards .cards-card-body {
@@ -17,11 +29,108 @@
 }
 
 .cards .cards-card-image {
-  line-height: 0;
+  height: 180px;
+  overflow: hidden;
+  border-radius: 16px 16px 0px 0px;
 }
 
 .cards > ul > li img {
   width: 100%;
-  aspect-ratio: 4 / 3;
   object-fit: cover;
+  transition: transform 0.3s ease;
+}
+
+.cards > ul > li:hover img {
+  transform: scale(1.05); 
+}
+
+.cards > ul > li > a {
+  text-decoration: none;
+  color: inherit;
+}
+
+.cards .cards-card-body > p {
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 130%;
+  margin: 18px 0 0;
+}
+
+.cards .cards-card-body > h3 {
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 130%;
+  margin: 0px;
+}
+
+
+.text-cards-links h2 {
+  text-align: center;
+}
+
+
+@media (max-width: 1600px) {
+  .cards > ul {
+    max-width: 1500px; /* Limits the maximum width of the cards container */
+    margin: 0;
+    flex-wrap: wrap;
+  }
+
+  .cards > ul > li {
+    width: 448px;
+    height: 314px;
+  }
+  .cards-card-body {
+    height: 169px;
+  }
+}
+
+@media (max-width: 1280px) {
+  .cards > ul {
+    flex-wrap: wrap;
+    width: 100%;
+    margin: 0;
+
+  }
+
+  .cards > ul > li {
+    width: 355px;
+    height: 375px;
+  }
+  .cards-card-body {
+    height: 230px;
+  }
+}
+
+@media (max-width: 900px) {
+  .cards > ul {
+    flex-wrap: wrap;
+    width: 100%;
+    margin: 0;
+
+  }
+
+  .cards > ul > li {
+    width: 408px;
+    height: 355px;
+  }
+  .cards-card-body {
+    height: 210px;
+  }
+}
+
+@media (max-width: 600px) {
+  .cards > ul {
+    margin: 0;
+  }
+
+  .cards > ul > li {
+    width: 272px;
+    height: 400px;
+  }
+  .cards-card-body {
+    height: 255px;
+  }
 }

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -20,7 +20,7 @@ export default function decorate(block) {
     const thirdColumn = li.children[2]; // Get the third child (0-based index)
     if (thirdColumn && thirdColumn.querySelector('a')) {
       const link = thirdColumn.querySelector('a'); // Get the link
-      const href = link.href; // Extract the href attribute
+      const { href } = link; // Extract the href attribute using destructuring
 
       // Remove the text content of the link
       link.textContent = ''; // Clears any text inside the <a> tag

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -6,12 +6,36 @@ export default function decorate(block) {
   [...block.children].forEach((row) => {
     const li = document.createElement('li');
     while (row.firstElementChild) li.append(row.firstElementChild);
+
+    // Assign classes to div elements before wrapping in a link
     [...li.children].forEach((div) => {
-      if (div.children.length === 1 && div.querySelector('picture')) div.className = 'cards-card-image';
-      else div.className = 'cards-card-body';
+      if (div.children.length === 1 && div.querySelector('picture')) {
+        div.className = 'cards-card-image';
+      } else {
+        div.className = 'cards-card-body';
+      }
     });
+
+    // Check if the third column exists and contains a link
+    const thirdColumn = li.children[2]; // Get the third child (0-based index)
+    if (thirdColumn && thirdColumn.querySelector('a')) {
+      const link = thirdColumn.querySelector('a'); // Get the link
+      const href = link.href; // Extract the href attribute
+
+      // Remove the text content of the link
+      link.textContent = ''; // Clears any text inside the <a> tag
+
+      // Wrap the entire <li> content in the link
+      const wrapperLink = document.createElement('a');
+      wrapperLink.href = href;
+      wrapperLink.style.display = 'block'; // Ensure the link covers the entire <li>
+      while (li.firstChild) wrapperLink.append(li.firstChild); // Move all children into the link
+      li.append(wrapperLink); // Append the link back to the <li>
+    }
+
     ul.append(li);
   });
+
   ul.querySelectorAll('picture > img').forEach((img) => img.closest('picture').replaceWith(createOptimizedPicture(img.src, img.alt, false, [{ width: '750' }])));
   block.textContent = '';
   block.append(ul);


### PR DESCRIPTION
Updated cards.css to style card blocks similar to Spectrum card block style. Added new feature to cards.js to allow a third column containing a link when using the card block that links the contents of the card. Created a draft for the index page containing new block content under /drafts/lgilbert/index.docx
	modified:   blocks/cards/cards.css
	modified:   blocks/cards/cards.js

Fix https://github.com/aemsites/ams-lts/issues/7

Test URLs:
    Before: https://main--ams-lts--aemsites.aem.page/
    After: https://7-card-style--ams-lts--aemsites.aem.page/drafts/lgilbert/

Instructions for how to review:
Scroll down to the card block section "Your AEM 6.5 LTS Upgrade Journey Starts Here", compare block styling to https://s2.spectrum.adobe.com/