### PR TITLE
36 acardion block

### DIFF
--- a/blocks/acardion/acardion.css
+++ b/blocks/acardion/acardion.css
@@ -83,6 +83,20 @@
     align-self: center; /* Center the arrow below the preview text */
   }
   
+  /* Styling for preview text */
+  .acardion-preview-text {
+    font-size: 14px;
+    font-weight: 400;
+    color: gray; /* Use a lighter color to differentiate from the header */
+    margin-top: 8px; /* Add spacing below the header */
+    white-space: nowrap; /* Ensure preview text stays on a single line */
+    overflow: hidden; /* Prevent overflow if text is too long */
+    text-overflow: ellipsis; /* Add ellipsis if text overflows */
+    display: block; /* Ensure it appears below the header */
+    text-align: left; /* Keep preview text aligned to the left */
+    transition: opacity 0.3s ease, transform 0.3s ease; /* Smooth transition for disappearing */
+  }
+
   /* Rotate arrow when accordion is expanded */
   .acardion-item[open] .acardion-item-label::after {
     transform: rotate(-135deg); /* Rotates the arrow when expanded */
@@ -92,8 +106,8 @@
   .acardion-item[open] .acardion-preview-text {
     opacity: 0; /* Fade out the preview text */
     transform: translateY(-10px); /* Move the preview text slightly upwards */
-    margin-top: 0px;
-    height: 0px;
+    margin-top: 0;
+    height: 0;
   }
   
   /* Reduce padding when preview text is hidden */
@@ -113,31 +127,11 @@
     max-height: 0; /* Initially hidden */
     transition: max-height 0.3s ease, padding 0.3s ease; /* Smooth transition */
   }
-  
+
   /* When the accordion is expanded */
   .acardion-item[open] .acardion-item-body {
     max-height: 500px; /* Adjust based on expected content height */
     padding: 16px; /* Restores padding when expanded */
-  }
-
-/* Styling for preview text */
-.acardion-preview-text {
-    font-size: 14px;
-    font-weight: 400;
-    color: gray; /* Use a lighter color to differentiate from the header */
-    margin-top: 8px; /* Add spacing below the header */
-    white-space: nowrap; /* Ensure preview text stays on a single line */
-    overflow: hidden; /* Prevent overflow if text is too long */
-    text-overflow: ellipsis; /* Add ellipsis if text overflows */
-    display: block; /* Ensure it appears below the header */
-    text-align: left; /* Keep preview text aligned to the left */
-    transition: opacity 0.3s ease, transform 0.3s ease; /* Smooth transition for disappearing */
-  }
-  
-  /* Hide preview text when accordion is expanded */
-  .acardion-item[open] .acardion-preview-text {
-    opacity: 0; /* Fade out the preview text */
-    transform: translateY(-10px); /* Move the preview text slightly upwards */
   }
 
   /* Responsive styles */

--- a/blocks/acardion/acardion.css
+++ b/blocks/acardion/acardion.css
@@ -1,0 +1,189 @@
+/* Container for all cards */
+.acardion-container {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 32px 64px;
+    margin: 0;
+  }
+  
+  .acardion-container > .default-content-wrapper {
+    margin: 0;
+  }
+    
+  /* Individual card */
+  .acardion-card {
+    height: 375px;
+    width: 448px;
+    border-radius: 16px;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    color: black; /* Ensures text defaults to black */
+  }
+  
+  /* Image section */
+  .acardion-card-image-header {
+    height: 180px;
+    overflow: hidden;
+    border-radius: 16px 16px 0 0;
+  }
+  
+  .acardion-card-image-header img {
+    width: 100%;
+    object-fit: cover;
+    transition: transform 0.3s ease;
+  }
+  
+  .acardion-card:hover img {
+    transform: scale(1.05);
+  }
+  
+/* Ensure header text appears properly */
+.acardion-card-header {
+    font-size: 20px;
+    font-weight: 700;
+    line-height: 130%;
+    margin: 0; /* Remove margin to align with preview text */
+    color: black; /* Ensures header text is black */
+    text-align: left; /* Keep header aligned to the left */
+  }
+  
+/* Adjust accordion label to include header and preview text */
+.acardion-item-label {
+    display: flex; /* Align header, preview text, and arrow vertically */
+    flex-direction: column; /* Stack header, preview text, and arrow vertically */
+    align-items: flex-start; /* Align header and preview text to the left */
+    padding: 16px;
+    cursor: pointer;
+    background-color: var(--light-color);
+    font-size: 16px;
+    font-weight: 700;
+    line-height: 130%;
+    transition: background-color 0.2s, padding 0.3s ease; /* Smooth transition for padding */
+    color: black; /* Ensures accordion label text is black */
+  }
+
+  .acardion-item-label:hover {
+    background-color: #A3E4D7;
+  }
+  
+/* Arrow indicator */
+.acardion-item-label::after {
+    content: '';
+    display: inline-block;
+    margin-top: 8px; /* Add spacing below the preview text */
+    width: 8px;
+    height: 8px;
+    border: solid black;
+    border-width: 0 2px 2px 0;
+    transform: rotate(45deg); /* Creates the arrow shape */
+    transition: transform 0.2s ease;
+    align-self: center; /* Center the arrow below the preview text */
+  }
+  
+  /* Rotate arrow when accordion is expanded */
+  .acardion-item[open] .acardion-item-label::after {
+    transform: rotate(-135deg); /* Rotates the arrow when expanded */
+  }
+  
+  /* Hide preview text when accordion is expanded */
+  .acardion-item[open] .acardion-preview-text {
+    opacity: 0; /* Fade out the preview text */
+    transform: translateY(-10px); /* Move the preview text slightly upwards */
+    margin-top: 0px;
+    height: 0px;
+  }
+  
+  /* Reduce padding when preview text is hidden */
+  .acardion-item[open] .acardion-item-label {
+    padding: 8px 16px; /* Reduce padding to remove blank white space */
+  }
+
+/* Accordion body */
+.acardion-item-body {
+    padding: 16px;
+    font-size: 16px;
+    font-weight: 400;
+    line-height: 130%;
+    color: black; /* Ensures accordion body text is black */
+    background-color: var(--background-color); /* White background */
+    overflow: hidden; /* Prevents content from overflowing */
+    max-height: 0; /* Initially hidden */
+    transition: max-height 0.3s ease, padding 0.3s ease; /* Smooth transition */
+  }
+  
+  /* When the accordion is expanded */
+  .acardion-item[open] .acardion-item-body {
+    max-height: 500px; /* Adjust based on expected content height */
+    padding: 16px; /* Restores padding when expanded */
+  }
+
+/* Styling for preview text */
+.acardion-preview-text {
+    font-size: 14px;
+    font-weight: 400;
+    color: gray; /* Use a lighter color to differentiate from the header */
+    margin-top: 8px; /* Add spacing below the header */
+    white-space: nowrap; /* Ensure preview text stays on a single line */
+    overflow: hidden; /* Prevent overflow if text is too long */
+    text-overflow: ellipsis; /* Add ellipsis if text overflows */
+    display: block; /* Ensure it appears below the header */
+    text-align: left; /* Keep preview text aligned to the left */
+    transition: opacity 0.3s ease, transform 0.3s ease; /* Smooth transition for disappearing */
+  }
+  
+  /* Hide preview text when accordion is expanded */
+  .acardion-item[open] .acardion-preview-text {
+    opacity: 0; /* Fade out the preview text */
+    transform: translateY(-10px); /* Move the preview text slightly upwards */
+  }
+
+  /* Responsive styles */
+  @media (width <= 1600px) {
+    .acardion-container {
+      max-width: 1500px;
+      margin: 0;
+    }
+  
+    .acardion-card {
+      width: 448px;
+      height: 375px;
+    }
+  }
+  
+  @media (width <= 1280px) {
+    .acardion-container {
+      width: 100%;
+      margin: 0;
+    }
+  
+    .acardion-card {
+      width: 355px;
+      height: 375px;
+    }
+  }
+  
+  @media (width <= 900px) {
+    .acardion-container {
+      width: 100%;
+      margin: 0;
+    }
+  
+    .acardion-card {
+      width: 408px;
+      height: 375px;
+    }
+  }
+  
+  @media (width <= 600px) {
+    .acardion-container {
+      margin: 0;
+    }
+  
+    .acardion-card {
+      width: 272px;
+      height: 400px;
+    }
+  }

--- a/blocks/acardion/acardion.js
+++ b/blocks/acardion/acardion.js
@@ -1,0 +1,63 @@
+import { createOptimizedPicture } from '../../scripts/aem.js';
+
+export default function decorate(block) {
+  const container = document.createElement('div');
+  container.className = 'acardion-container';
+
+  [...block.children].forEach((row) => {
+    // Create individual card
+    const card = document.createElement('div');
+    card.className = 'acardion-card';
+
+    // Create card image and header
+    const imageAndHeader = document.createElement('div');
+    imageAndHeader.className = 'acardion-card-image-header';
+
+    const imageCell = row.children[0];
+    const picture = imageCell.querySelector('picture');
+    if (picture) {
+      const img = picture.querySelector('img');
+      const optimizedPicture = createOptimizedPicture(img.src, img.alt, false, [{ width: '750' }]);
+      optimizedPicture.className = 'acardion-card-image';
+      imageAndHeader.append(optimizedPicture);
+    }
+
+    // Create accordion for paragraph text
+    const accordionCell = row.children[1];
+    const details = document.createElement('details');
+    details.className = 'acardion-item';
+
+    const summary = document.createElement('summary');
+    summary.className = 'acardion-item-label';
+
+    // Move header into the accordion label
+    const header = document.createElement('h3');
+    header.className = 'acardion-card-header';
+    header.textContent = imageCell.querySelector('h3')?.textContent || '';
+    summary.append(header); // Append header to the accordion label
+
+    // Add preview text below the header
+    const paragraph = accordionCell.querySelector('p');
+    if (paragraph) {
+      const previewText = document.createElement('span');
+      previewText.className = 'acardion-preview-text';
+      const fullText = paragraph.textContent.trim();
+      previewText.textContent = fullText.length > 65
+        ? `${fullText.slice(0, 65)}...` // Limit to 60 characters and add "..."
+        : fullText; // Use full text if it's shorter than 60 characters
+      summary.append(previewText); // Append preview text below the header
+
+      const body = document.createElement('div');
+      body.className = 'acardion-item-body';
+      body.append(paragraph);
+      details.append(body);
+    }
+
+    details.append(summary);
+    card.append(imageAndHeader, details);
+    container.append(card);
+  });
+
+  block.innerHTML = '';
+  block.append(container);
+}


### PR DESCRIPTION
Fix #36 

Test URLs:
- Before: https://main--ams-lts--aemsites.aem.page/drafts/lgilbert2/
- After: https://36-acardion-block--ams-lts--aemsites.aem.page/drafts/lgilbert2/

Instructions for how to review:
Adds new acardion class that is authored similar to a card or accordion block, the left column expects an h3 and an image for the acardion image and title, the right column the text to be displayed when the acardion is expanded.

To review go to the "After" URL, scroll down to "Take advantage of all the latest Adobe Managed Services AEM Innovations". The acardions should be displayed with the images, title, preview text and an arrow indicating they can be expanded. Mousing over the arrow should high light the area, clicking expands the acardion displaying the text from the right column, arrow should update to indicate it can be closed, the expansion of the card should be done in place and not cause the rest of the acardions to be re-arranged. Clicking the arrow again should collapse the card and update the arrow to the original position.