### PR TITLE
	modified:   blocks/acardion/acardion.css

### DIFF
--- a/blocks/acardion/acardion.css
+++ b/blocks/acardion/acardion.css
@@ -32,6 +32,7 @@
   
   .acardion-card-image-header img {
     width: 100%;
+    height: 100%;
     object-fit: cover;
     transition: transform 0.3s ease;
   }
@@ -173,6 +174,7 @@
   
   @media (width <= 600px) {
     .acardion-container {
+      width: 100%;
       margin: 0;
     }
   

--- a/blocks/acardion/acardion.js
+++ b/blocks/acardion/acardion.js
@@ -41,10 +41,35 @@ export default function decorate(block) {
     if (paragraph) {
       const previewText = document.createElement('span');
       previewText.className = 'acardion-preview-text';
-      const fullText = paragraph.textContent.trim();
-      previewText.textContent = fullText.length > 65
-        ? `${fullText.slice(0, 65)}...` // Limit to 60 characters and add "..."
-        : fullText; // Use full text if it's shorter than 60 characters
+
+      const updatePreviewText = () => {
+        const fullText = paragraph.textContent.trim();
+
+        // Adjust maxLength based on responsive sizes
+        let maxLength = 65; // Default preview text length
+        const viewportWidth = window.innerWidth;
+
+        if (viewportWidth <= 600) {
+          maxLength = 38; // For widths <= 600px
+        } else if (viewportWidth <= 900) {
+          maxLength = 60; // For widths <= 900px
+        } else if (viewportWidth <= 1280) {
+          maxLength = 50; // For widths <= 1280px
+        } else if (viewportWidth <= 1600) {
+          maxLength = 65; // For widths <= 1600px
+        }
+
+        previewText.textContent = fullText.length > maxLength
+          ? `${fullText.slice(0, maxLength)}...`
+          : fullText;
+      };
+
+      // Initial calculation
+      updatePreviewText();
+
+      // Update preview text on window resize
+      window.addEventListener('resize', updatePreviewText);
+
       summary.append(previewText); // Append preview text below the header
 
       const body = document.createElement('div');


### PR DESCRIPTION
Fix #39 

Resolves issue in acardion.js with the preview text and responsive styles at lower view point widths causing the text to be cut off when he acardion block is adjusted smaller by adjusting the max text length based on the same sizes in acardion.css

Also resolved an issue in acardion.css found in testing where the card images are not utilizing the full height of the acardion block at lower view port sizes causing them to be disconnected from the acardion body.

Test URLs:
- Before: https://main--ams-lts--aemsites.aem.page/
- After: https://39-preview-text--ams-lts--aemsites.aem.page/#take-advantage-of-all-the-latest-adobe-managed-services-aem-innovations

Instructions for how to review:
Go to the "After" URL, scroll or click the link for "Take advantage of all the latest Adobe Managed Services AEM Innovations" section. Adjust the view port width to the different break points, 1600px, 1280px, 900px and 600px.

The preview card text should never be cut off abruptly, it should end with "..." indicating there is more to read. The acardion body containing the header and preview text should also stay attached to the acardion image at all sizes.
