### PR TITLE
fix carousel height

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -151,6 +151,7 @@
   cursor: grab; /* Show grab cursor for drag affordance */
   user-select: none; /* Prevent text selection during drag */
   -webkit-overflow-scrolling: touch; /* Smooth scrolling on touch devices */
+  line-height: 1.4;
 }
 
 .cards.cardousel.block > ul {
@@ -171,6 +172,7 @@ body > main > div:nth-child(9) > div > div > ul > li:nth-child(5) {
     overflow: hidden;
     justify-content: unset;
     min-width: 448px;
+    height: 400px;
 }
 
 .cards.cardousel.block > ul > li::before {


### PR DESCRIPTION
text line-height and card height changes should show all the text in those now without getting cut off.

Fix #48 

Test URLs:
- Before: https://main--ams-lts--aemsites.aem.page/
- After: https://48-cardouselheight--ams-lts--aemsites.aem.page/


