### PR TITLE
62 acardion corners

### DIFF
--- a/blocks/acardion/acardion.css
+++ b/blocks/acardion/acardion.css
@@ -62,6 +62,7 @@
     font-size: 16px;
     font-weight: 700;
     line-height: 130%;
+    border-radius: 0 0 16px 16px;
     transition: background-color 0.2s, padding 0.3s ease; /* Smooth transition for padding */
     color: black; /* Ensures accordion label text is black */
   }
@@ -114,6 +115,7 @@
   /* Reduce padding when preview text is hidden */
   .acardion-item[open] .acardion-item-label {
     padding: 8px 16px; /* Reduce padding to remove blank white space */
+    border-radius: 0;
   }
 
 /* Accordion body */
@@ -133,6 +135,7 @@
   .acardion-item[open] .acardion-item-body {
     max-height: 500px; /* Adjust based on expected content height */
     padding: 16px; /* Restores padding when expanded */
+    border-radius: 0 0 16px 16px;
   }
 
   /* Responsive styles */


### PR DESCRIPTION
Fix #62 

Modifies acardion.css so that rounder corners are applied correctly to the accardion items and labels whether collapsed or expanded.

Test URLs:
- Before: https://main--ams-lts--aemsites.aem.page/
- After: https://62-acardion-corners--ams-lts--aemsites.aem.page/

Instructions for how to review:
Go to the after URL and scroll down to the "Take advantage of all the latest Adobe Managed Services AEM Innovations". The acardions below this section should all have rounded corners when collapsed. Expand each acardion and verify that corners are still rounded when expanded.